### PR TITLE
[OOE-101] explicitly exit 0 for kubernetes init container

### DIFF
--- a/agent/sidecar/rootless/alpine/Dockerfile
+++ b/agent/sidecar/rootless/alpine/Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /opt/takipi
 RUN echo "#!/bin/sh" > run.sh \
  && echo "cat /opt/takipi/VERSION" >> run.sh \
  && echo "cp -a /opt/takipi/. /takipi/" >> run.sh \
+ && echo "exit 0" >> run.sh \
  && chmod +x run.sh
 
 CMD ["./run.sh"]

--- a/agent/sidecar/rootless/linux/Dockerfile
+++ b/agent/sidecar/rootless/linux/Dockerfile
@@ -29,6 +29,7 @@ WORKDIR /opt/takipi
 RUN echo "#!/bin/bash" > run.sh \
  && echo "cat /opt/takipi/VERSION" >> run.sh \
  && echo "cp -a /opt/takipi/. /takipi/" >> run.sh \
+ && echo "exit 0" >> run.sh \
  && chmod +x run.sh
 
 CMD ["./run.sh"]


### PR DESCRIPTION
During testing, we found explicitly calling `exit 0` is needed for the kubernetes init container to continue successfully.

@takipi-field/keymaker please review and merge